### PR TITLE
Fix error for multilingual setups when no groups are activated

### DIFF
--- a/src/controllers/XmlSitemapController.php
+++ b/src/controllers/XmlSitemapController.php
@@ -53,7 +53,7 @@ class XmlSitemapController extends Controller
             $firstSiteInGroup = $sitesInGroup[0] ?? null;
 
             // Only render sitemaps for the primary site in a group
-            if ($firstSiteInGroup == null || $siteId !== $firstSiteInGroup->id) {
+            if ($firstSiteInGroup === null || $siteId !== $firstSiteInGroup->id) {
                 throw new HttpException(404);
             }
 

--- a/src/controllers/XmlSitemapController.php
+++ b/src/controllers/XmlSitemapController.php
@@ -50,10 +50,10 @@ class XmlSitemapController extends Controller
 
         if (Craft::$app->getIsMultiSite() && $isMultilingualSitemap) {
             $sitesInGroup = SproutBaseSitemaps::$app->xmlSitemap->getCurrentSitemapSites();
-            $firstSiteInGroup = $sitesInGroup[0];
+            $firstSiteInGroup = $sitesInGroup[0] ?? null;
 
             // Only render sitemaps for the primary site in a group
-            if ($siteId !== $firstSiteInGroup->id) {
+            if ($firstSiteInGroup == null || $siteId !== $firstSiteInGroup->id) {
                 throw new HttpException(404);
             }
 


### PR DESCRIPTION
This fixes an error when opening the sitemap.xml if "Enable multi-lingual sitemaps" and no site group is activated. 